### PR TITLE
Update package.json to link npm to github

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
   "scripts": {
     "release": "standard-version"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/valora-inc/eslint-config-typescript.git"
+  },
   "dependencies": {
     "@typescript-eslint/parser": "^7.1.1"
   },


### PR DESCRIPTION
Currently on npmjs, users cannot go find the github repo because it's not linked. You need to denote the github repo inside the package.json in-order for npm to link users to github. This helps with visibility so folks can learn more about the code they are downloading:

https://www.npmjs.com/package/@valora/eslint-config-typescript

<img width="1840" alt="skitch" src="https://github.com/dawsbot/eslint-config-typescript/assets/3408480/de2fbf1c-af67-479a-928d-e015de47d314">
